### PR TITLE
Send 200 response on success rather than mirror [SATURN-1466]

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -79,7 +79,7 @@ const main = async () => {
     log(req.body)
     token && sendToMixpanel(token, event, properties)
 
-    return new Response(200, { event, properties })
+    return new Response(200)
   })))
 }
 


### PR DESCRIPTION
Send an empty 200 response on success instead of mirroring the request back to the sender