### PR TITLE
update identity and email handling [SATURN-1521]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 /docs/
+/config.json
 
 /.idea/
 jsconfig.json

--- a/config/alpha.json
+++ b/config/alpha.json
@@ -1,4 +1,5 @@
 {
   "project": "terra-bard-alpha",
+  "orchestrationRoot": "https://firecloud-orchestration.dsde-alpha.broadinstitute.org",
   "samRoot": "https://sam.dsde-alpha.broadinstitute.org"
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,4 +1,5 @@
 {
   "project": "terra-bard-dev",
+  "orchestrationRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
   "samRoot": "https://sam.dsde-dev.broadinstitute.org"
 }

--- a/config/perf.json
+++ b/config/perf.json
@@ -1,4 +1,5 @@
 {
   "project": "terra-bard-perf",
+  "orchestrationRoot": "https://firecloud-orchestration.dsde-perf.broadinstitute.org",
   "samRoot": "https://sam.dsde-perf.broadinstitute.org"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,4 +1,5 @@
 {
   "project": "terra-bard-prod",
+  "orchestrationRoot": "https://firecloud-orchestration.dsde-prod.broadinstitute.org",
   "samRoot": "https://sam.dsde-prod.broadinstitute.org"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -1,4 +1,5 @@
 {
   "project": "terra-bard-staging",
+  "orchestrationRoot": "https://firecloud-orchestration.dsde-staging.broadinstitute.org",
   "samRoot": "https://sam.dsde-staging.broadinstitute.org"
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,45 +1,50 @@
+const _ = require('lodash/fp')
 const express = require('express')
 const cors = require('cors')
 const bodyParser = require('body-parser')
 const { promiseHandler, Response, validateInput } = require('./utils')
-const { project, samRoot } = require('../config')
+const { project, orchestrationRoot, samRoot } = require('../config')
 const { logger, getSecret } = require('./google-utils')
 const btoa = require('btoa-lite')
 const fetch = require('node-fetch')
 const Joi = require('@hapi/joi')
 
-
-const withAuth = wrappedFn => async (req, ...args) => {
-  const authRes = await fetch(
-    `${samRoot}/register/user/v2/self/info`,
-    { headers: { authorization: req.headers.authorization } }
-  ).catch(() => {
-    throw new Response(503, 'Unable to contact auth service')
+const fetchOk = async (url, { serviceName, ...options } = {}) => {
+  const res = await fetch(url, options).catch(() => {
+    throw new Response(503, `Unable to contact ${serviceName} service`)
   })
-
-  if (authRes.status === 401) {
+  if (res.status === 401) {
     throw new Response(401, 'Unauthorized')
   }
-
-  if (!authRes.ok) {
-    console.error('Sam error', await authRes.text())
-    throw new Response(503, 'Failed to query auth service')
+  if (!res.ok) {
+    console.error(`${serviceName} error`, await res.text())
+    throw new Response(503, `Failed to query ${serviceName} service`)
   }
+  return res
+}
 
-  const { enabled } = await authRes.json()
-  if (!enabled) {
+const fetchMixpanel = async (url, { data, ...options } = {}) => {
+  const res = await fetchOk(
+    `https://api.mixpanel.com/${url}?data=${btoa(JSON.stringify(data))}`,
+    { serviceName: 'metrics', ...options }
+  )
+  const status = await res.text()
+  if (status !== '1') {
+    console.error(`Failed to log to mixpanel:`, data)
+    throw new Response(400, 'Error saving metrics data')
+  }
+}
+
+const withAuth = wrappedFn => async (req, ...args) => {
+  const res = await fetchOk(
+    `${samRoot}/register/user/v2/self/info`,
+    { headers: { authorization: req.headers.authorization }, serviceName: 'auth' }
+  )
+  req.user = await res.json()
+  if (!req.user.enabled) {
     throw new Response(403, 'Forbidden')
   }
   return wrappedFn(req, ...args)
-}
-
-const sendToMixpanel = async (token, event, props) => {
-  const data = btoa(JSON.stringify({ event, properties: { token, ...props } }))
-  try {
-    await fetch(`https://api.mixpanel.com/track?data=${data}`)
-  } catch (error) {
-    console.error(`Failed to log ${data} to mixpanel`)
-  }
 }
 
 const main = async () => {
@@ -64,39 +69,68 @@ const main = async () => {
     return new Response(200)
   }))
 
-  const eventSchema = Joi.string().required()
+  const eventSchema = Joi.string().pattern(/^\$/, { invert: true }).required()
   const propertiesSchema = Joi.object({
-    userId: Joi.string().required(),
-    appId: Joi.string().required(),
-    appPath: Joi.string().required(),
-    timestamp: Joi.date().timestamp().required()
-  }).required().unknown(true)
+    token: Joi.any().forbidden(),
+    'distinct_id': Joi.any().forbidden(),
+    time: Joi.any().forbidden(),
+    ip: Joi.any().forbidden(),
+    name: Joi.any().forbidden(),
+    appId: Joi.string().required()
+  }).pattern(Joi.string().pattern(/^(\$|mp_)/, { invert: true }), Joi.any().required()).required()
 
   /**
-   * @api {post} /event Log a user event
+   * @api {post} /api/event Log a user event
    * @apiDescription Records the event to a log and forwards it to mixpanel
    * @apiName event
    * @apiVersion 1.0.0
    * @apiGroup Events
    * @apiParam {String} event Name of the event
    * @apiParam {Object} properties Properties associated with this event. The below fields are required. Additional application defined fields can also be used
-   * @apiParam {String} properties.userId The anonymized ID of the user
    * @apiParam {String} properties.appId The application
-   * @apiParam {String} properties.appPath The navigational path in the application the user is on, with identifying parameters removed
-   * @apiParam {Date} properties.timestamp Timestamp of the event
    * @apiSuccess (Success 200) -
    */
   app.post('/api/event', promiseHandler(withAuth(async req => {
-    const { event, properties } = req.body
-
     validateInput(req.body, Joi.object({ event: eventSchema, properties: propertiesSchema }))
-
-    log(req.body)
-    token && sendToMixpanel(token, event, properties)
-
+    const data = _.update('properties', properties => ({
+      ...properties,
+      token,
+      'distinct_id': `google:${req.user.userSubjectId}`,
+      ip: req.ip
+    }), req.body)
+    await Promise.all([
+      log(data),
+      token && fetchMixpanel('track', { data })
+    ])
     return new Response(200)
   })))
+
+  /**
+   * @api {post} /api/syncProfile Update mixpanel profile
+   * @apiDescription Syncs profile info from orchestration to mixpanel
+   * @apiName syncProfile
+   * @apiVersion 1.0.0
+   * @apiGroup Profile
+   * @apiSuccess (Success 200) -
+   */
+  app.post('/api/syncProfile', promiseHandler(async req => {
+    const res = await fetchOk(
+      `${orchestrationRoot}/register/profile`,
+      { headers: { authorization: req.headers.authorization }, serviceName: 'profile' }
+    )
+    const { userId, keyValuePairs } = await res.json()
+    const email = _.get('value', _.find({ key: 'anonymousGroup' }, keyValuePairs))
+    const data = {
+      '$token': token,
+      '$distinct_id': `google:${userId}`,
+      '$ip': req.ip,
+      '$set': { '$email': email }
+    }
+    if (token) {
+      await fetchMixpanel('engage', { data })
+    }
+    return new Response(200)
+  }))
 }
 
 main().catch(console.error)
-

--- a/src/server.js
+++ b/src/server.js
@@ -95,8 +95,7 @@ const main = async () => {
     const data = _.update('properties', properties => ({
       ...properties,
       token,
-      'distinct_id': `google:${req.user.userSubjectId}`,
-      ip: req.ip
+      'distinct_id': `google:${req.user.userSubjectId}`
     }), req.body)
     await Promise.all([
       log(data),
@@ -123,7 +122,6 @@ const main = async () => {
     const data = {
       '$token': token,
       '$distinct_id': `google:${userId}`,
-      '$ip': req.ip,
       '$set': { '$email': email }
     }
     if (token) {


### PR DESCRIPTION
This changes the handling of certain fields to integrate better with Mixpanel tools:
* Forbids passing reserved events or properties directly from the client, to prevent faking important data.
* Provides a `distinct_id` property based on the user id reported from Sam. This field is used by Mixpanel as the primary key for a user. We add a prefix string, with the intention of enforcing a separation between 'verified' and 'unverified' identities, once we enable an unauthenticated endpoint.
* Separates the handling of the anonymous email into a new endpoint that uses Mixpanel's 'profile' feature, which should ensure that messaging works properly. This will need to be called at least once per user, so e.g. on initial load/login.