### PR TITLE
add deploy script and fix gcloudignore

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -15,3 +15,4 @@
 #!include:.gitignore
 
 !/docs/
+!/config.json

--- a/scripts/deploy-all-but-prod.sh
+++ b/scripts/deploy-all-but-prod.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+yarn install
+yarn run lint
+yarn run generate-docs
+
+for TERRA_ENV in dev alpha perf staging ; do
+    cp config/$TERRA_ENV.json config.json
+    gcloud app deploy --project=terra-bard-$TERRA_ENV --promote --quiet
+done
+
+rm config.json


### PR DESCRIPTION
This adds a deploy-all-but-prod script, similar to our other projects, and whitelists `config.json` in .gcloudignore to ensure it gets uploaded.

Tested implicitly while deploying the recent feature branch.