### PR TITLE
[SATURN-1578] Enable Anon-User Tracking

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -42,10 +42,7 @@ const fetchMixpanel = async (url, { data, ...options } = {}) => {
 const verifyAuth = async req => {
   const res = await fetchOk(
     `${samRoot}/register/user/v2/self/info`,
-    {
-      headers: { authorization: req.headers.authorization },
-      serviceName: 'auth'
-    }
+    { headers: { authorization: req.headers.authorization }, serviceName: 'auth' }
   )
   req.user = await res.json()
   if (!req.user.enabled) {
@@ -140,9 +137,7 @@ const main = async () => {
    * @apiSuccess (Success 200) -
    */
   app.post('/api/identify', promiseHandler(withAuth(async req => {
-    validateInput(req.body, Joi.object({
-      anonId: identifySchema
-    }))
+    validateInput(req.body, Joi.object({ anonId: identifySchema }))
 
     const data = {
       event: '$identify',

--- a/src/server.js
+++ b/src/server.js
@@ -106,7 +106,9 @@ const main = async () => {
    * @apiVersion 1.0.0
    * @apiGroup Events
    * @apiParam {String} event Name of the event
-   * @apiParam {Object} properties Properties associated with this event. The below fields are required. Additional application defined fields can also be used
+   * @apiParam {Object} properties Properties associated with this event. If the user is registered, the distinct_id property will
+   * be auto-populated and is forbidden to be passed by the client, if the user is anonymous a distinct_id in uuid4 format passed
+   * by the client is required. Additional application defined fields can also be used.
    * @apiParam {String} properties.appId The application
    * @apiSuccess (Success 200) -
    */

--- a/src/server.js
+++ b/src/server.js
@@ -130,10 +130,10 @@ const main = async () => {
   /**
    * @api {post} /api/identify Merge two user id's
    * @apiDescription Calls MixPanel's `$identify` endpoint to merge the included distinct_ids
-   * @apiName event
+   * @apiName identify
    * @apiVersion 1.0.0
    * @apiGroup Events
-   * @apiParam {Object} properties Properties associated with this event. The below fields are required. Additional application defined fields can also be used
+   * @apiParam {String} The distinct id of an anonymous user, this is required
    * @apiSuccess (Success 200) -
    */
   app.post('/api/identify', promiseHandler(withAuth(async req => {
@@ -148,6 +148,7 @@ const main = async () => {
       }
     }
     await Promise.all([
+      log(data),
       token && fetchMixpanel('track', { data })
     ])
     return new Response(200)

--- a/src/server.js
+++ b/src/server.js
@@ -106,9 +106,8 @@ const main = async () => {
    * @apiVersion 1.0.0
    * @apiGroup Events
    * @apiParam {String} event Name of the event
-   * @apiParam {Object} properties Properties associated with this event. If the user is registered, the distinct_id property will
-   * be auto-populated and is forbidden to be passed by the client, if the user is anonymous a distinct_id in uuid4 format passed
-   * by the client is required. Additional application defined fields can also be used.
+   * @apiParam {Object} properties Properties associated with this event. Additional application defined fields can also be used.
+   * @apiParam (Unregistered) {String{uuid4}} properties.distinct_id The id of the anon user required for client to pass if user is unregistered (forbidden if user is registered)
    * @apiParam {String} properties.appId The application
    * @apiSuccess (Success 200) -
    */


### PR DESCRIPTION
Two changes:

1. Change existing log event endpoint so that the user being authenticated is optional thus allowing for tracking events from an unregistered user.
2. Add an endpoint to call the MixPanel endpoint "$identity" which will merge together two distinct ids (our use case would be for the anon-id to a register-user-id).

Tested:
- Sending anonymous events to MixPanel
- Identifying events of a registered user with an anonymous user
- Re-tested existing functionality of sending registered user events
- Tried a variety of invalid inputs to ensure only the correctly formatted data will get through

To Test Locally:
1. You need Bard running and TerraUI running
2. In the console on your browser window you need to set your local Bard as the service for the browser to use with: `configOverridesStore.set({bardRoot: 'http://localhost:8080'})`
3. Registered user events will get sent automatically as that is already set up
4. To send unregistered you need to make a change in your local TerraUI code, I did the following:
In `ajax.js` I added:
```
` captureAnonEvent: withErrorIgnoring((event, details = {}) => {
    const body = {
      event,
      properties: {
        ...details,
        appId: 'Saturn',
        hostname: window.location.hostname,
        appPath: Nav.getCurrentRoute().name
      }
    }

    return fetchBard('api/event', _.mergeAll([jsonBody(body), { signal, method: 'POST' }]))
  }),

  mergeEvent: withErrorIgnoring(anonId => {
    const body = {
      anonId
    }
    return fetchBard('api/identify', _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]))
  }),
```

within `const Metrics`

Then in the console on your browser you can test sending anon events with:
`Ajax().Metrics.captureAnonEvent('event_name', {distinct_id: 'A UUID4 string'})
`
and test merging to your logged in account with:
`Ajax().Metrics.mergeEvent('A UUID4 string')`

Then you need to check the MixPanel dashboard to see the events come through: https://mixpanel.com/report/2085496/live#chosen_columns:!('$browser','$city',mp_country_code,distinct_id,'$referring_domain',userId),column_widths:!(200,100,125,85,125,143,210,112),query:(event_selectors:!())