### PR TITLE
fix prod orchestration url

### DIFF
--- a/config/prod.json
+++ b/config/prod.json
@@ -1,5 +1,5 @@
 {
   "project": "terra-bard-prod",
-  "orchestrationRoot": "https://firecloud-orchestration.dsde-prod.broadinstitute.org",
+  "orchestrationRoot": "https://api.firecloud.org",
   "samRoot": "https://sam.dsde-prod.broadinstitute.org"
 }


### PR DESCRIPTION
This is causing the `syncProfile` call to fail in prod only. Did not test directly since it's prod, but did verify that this value is now the same as the one in terra-ui.