### PR TITLE
Update gap in Bard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Note that there is currently no separate development environment for mixpanel, s
     yarn install
     ```
 3. To run bard locally you need to create a config.json in the root directory as there is no specified default config.
-   From within your local bard repo run the following command in the terminal:
+   To do so, run the following command in the terminal from within your local bard repo. (This will copy the dev config to a root version of config.json):
    
    ```sh
    cp config/dev.json config.json

--- a/README.md
+++ b/README.md
@@ -25,14 +25,19 @@ Note that there is currently no separate development environment for mixpanel, s
     ```sh
     yarn install
     ```
-
-3. Start a dev server on port 8080 with auto-reload
+3. To run bard locally you need to create a config.json in the root directory as there is no specified default config.
+   From within your local bard repo run the following command in the terminal:
+   
+   ```sh
+   cp config/dev.json config.json
+   
+4. Start a dev server on port 8080 with auto-reload
 
     ```sh
     GCP_PROJECT=terra-bard-dev GOOGLE_APPLICATION_CREDENTIALS=<path-to-key-file> yarn run start-dev
     ```
 
-4. Lint any code changes using 
+5. Lint any code changes using 
     ```sh
     yarn run lint
     ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note that there is currently no separate development environment for mixpanel, s
 
 1. Download a key for the app engine default service account terra-metrics-dev@appspot.gserviceaccount.com and note the location
 2. Install the dependencies
-   
+
     ```sh
     yarn install
     ```
@@ -30,14 +30,14 @@ Note that there is currently no separate development environment for mixpanel, s
    
    ```sh
    cp config/dev.json config.json
-   
+   ``` 
 4. Start a dev server on port 8080 with auto-reload
 
     ```sh
     GCP_PROJECT=terra-bard-dev GOOGLE_APPLICATION_CREDENTIALS=<path-to-key-file> yarn run start-dev
     ```
-
 5. Lint any code changes using 
+
     ```sh
     yarn run lint
     ```


### PR DESCRIPTION
We realized to run locally there is an extra step that isn't outlined in the Bard docs

Co-Authored-By: Brett Heath-Wlaz <panentheos@users.noreply.github.com>
Co-Authored-By: Cameron Ardell <cardell@broadinstitute.org>