### PR TITLE
HTTP-trigger cloud function [BT-51]

### DIFF
--- a/cloud_functions/README.md
+++ b/cloud_functions/README.md
@@ -11,5 +11,5 @@ This is a collection of cloud functions that augment the core bard service. The 
 
 ## Deployment
 ```sh
-gcloud --project terra-bard-[env] functions deploy flagCryptominer --runtime nodejs12 --trigger-topic cryptominers
+gcloud --project terra-bard-[env] functions deploy flagCryptominer --runtime nodejs12 --trigger-http
 ```

--- a/cloud_functions/flagCryptominer.js
+++ b/cloud_functions/flagCryptominer.js
@@ -4,11 +4,20 @@ const utils = require('./utils')
 
 const run = utils.withErrorReporting((mixpanel, message) => {
   const userSubjectId = validate(message)
-  return promisify(mixpanel.people.set)(`google:${userSubjectId}`, { 'isCryptominer': true })
+  return new Promise((resolve, reject) => {
+    mixpanel.people.set(`google:${userSubjectId}`, { 'isCryptominer': true },
+        error => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve()
+          }
+        })
+  })
 })
 
 const validate = message => {
-  if (!(message.attributes && message.attributes.cryptominer === true)) {
+  if (!(message.attributes && (message.attributes.cryptominer === true || message.attributes.cryptominer === 'true'))) {
     throw new Error('Unexpected message; missing `cryptominer: true` attribute. Is the Pub/Sub subscription set up correctly?')
   }
   const data = message.data && JSON.parse(Buffer.from(message.data, 'base64').toString())

--- a/cloud_functions/function.js
+++ b/cloud_functions/function.js
@@ -1,8 +1,10 @@
 const flagCryptominer = require('./flagCryptominer')
 const { getMixpanel } = require('./mixpanel')
+const { promiseHandler, Response } = require('./utils')
 
 
-module.exports.flagCryptominer = async (message, context) => {
+module.exports.flagCryptominer = promiseHandler(async (req, res) => {
   const mixpanel = await getMixpanel()
-  await flagCryptominer.run(mixpanel, message)
-}
+  await flagCryptominer.run(mixpanel, req.body.message)
+  return new Response(200)
+})


### PR DESCRIPTION
![thankyoumario](https://user-images.githubusercontent.com/19228696/105905610-a16d0b80-5ff0-11eb-9b4f-b672845b1138.gif)

In order to receive messages from a pub/sub topic in another project, we need a push subscription to an HTTP-triggered cloud function. This PR makes that change, as well as cleaning up a couple of other things that I found during a test deployment to dev.