### PR TITLE
[BT-667] Make the request:failed event a no-op

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,10 @@ const userDistinctId = user => {
   return `google:${user.userSubjectId}`
 }
 
+const delay = ms => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 const fetchOk = async (url, { serviceName, ...options } = {}) => {
   const res = await fetch(url, options).catch(() => {
     throw new Response(503, `Unable to contact ${serviceName} service`)
@@ -62,6 +66,30 @@ const withOptionalAuth = wrappedFn => async (req, ...args) => {
   return wrappedFn(req, ...args)
 }
 
+/**
+ * Temporary wrapper to ignore the 'request:failed' event and delay the repsonse to
+ * slow the browser requests down and reduce the errors, and getting the client out of
+ * the degenerative state. This wrapper will prevent calls to sam.
+ */
+const withBadEventHandling = (log, wrappedFn) => async (req, ...args) => {
+  const { event } = req.body
+
+  if (event === 'request:failed') {
+    const data = _.update('properties', properties => ({
+      ...properties,
+      event,
+      'distinct_id': req.user ? userDistinctId(req.user) : properties.distinct_id
+    }), req.body)
+
+    log(data)
+    await delay(10000)
+    return new Response(200)
+  } else {
+    return wrappedFn(req, ...args)
+  }
+}
+
+
 const main = async () => {
   const token = await getSecret({ project, secretName: 'mixpanel-api' })
   const log = logger({ project, logName: 'metrics' })
@@ -99,10 +127,6 @@ const main = async () => {
 
   const identifySchema = Joi.string().guid({ version: 'uuidv4' }).required()
 
-  const delay = ms => {
-    return new Promise(resolve => setTimeout(resolve, ms))
-  }
-
   /**
    * @api {post} /api/event Log a user event
    * @apiDescription Records the event to a log and forwards it to mixpanel. Optionally takes an authorization token which must be verified with Sam
@@ -115,7 +139,7 @@ const main = async () => {
    * @apiParam {String} properties.appId The application
    * @apiSuccess (Success 200) -
    */
-  app.post('/api/event', promiseHandler(withOptionalAuth(async req => {
+  app.post('/api/event', promiseHandler(withBadEventHandling(log, withOptionalAuth(async req => {
     validateInput(req.body, Joi.object({
       event: eventSchema,
       properties: propertiesSchema.tailor(req.user ? 'authenticated' : 'unauthenticated')
@@ -127,28 +151,12 @@ const main = async () => {
       'distinct_id': req.user ? userDistinctId(req.user) : properties.distinct_id
     }), req.body)
 
-    /**
-     * Temporary code to ignore the 'request:failed' event and delay the repsonse to
-     * slow the browser requests down and reduce the errors, and getting the client out of
-     * the degenerative state
-     */
-    const { event } = req.body
-    if (event === 'request:failed') {
-      const failedRequestData = _.update('properties', properties => ({
-        ...properties,
-        event
-      }), data)
-      log(failedRequestData)
-      await delay(10000)
-      return new Response(200)
-    }
-
     await Promise.all([
       log(data),
       token && fetchMixpanel('track', { data })
     ])
     return new Response(200)
-  })))
+  }))))
 
   /**
    * @api {post} /api/identify Merge two user id's

--- a/src/server.js
+++ b/src/server.js
@@ -136,7 +136,7 @@ const main = async () => {
     if (event === 'request:failed') {
       const failedRequestData = _.update('properties', properties => ({
         ...properties,
-        event: event
+        event
       }), data)
       log(failedRequestData)
       await delay(10000)

--- a/src/server.js
+++ b/src/server.js
@@ -144,13 +144,11 @@ const main = async () => {
       event: eventSchema,
       properties: propertiesSchema.tailor(req.user ? 'authenticated' : 'unauthenticated')
     }))
-
     const data = _.update('properties', properties => ({
       ...properties,
       token,
       'distinct_id': req.user ? userDistinctId(req.user) : properties.distinct_id
     }), req.body)
-
     await Promise.all([
       log(data),
       token && fetchMixpanel('track', { data })

--- a/src/server.js
+++ b/src/server.js
@@ -67,9 +67,10 @@ const withOptionalAuth = wrappedFn => async (req, ...args) => {
 }
 
 /**
- * Temporary wrapper to ignore the 'request:failed' event and delay the repsonse to
+ * Temporary wrapper to ignore the 'request:failed' event and delay the response to
  * slow the browser requests down and reduce the errors, and getting the client out of
  * the degenerative state. This wrapper will prevent calls to sam.
+ * Ticket: https://broadworkbench.atlassian.net/browse/BT-667
  */
 const withBadEventHandling = (log, wrappedFn) => async (req, ...args) => {
   const { event } = req.body


### PR DESCRIPTION
This is a temporary change to help get the browser client out of a degenerative state.

I tested this by pulling in the offending code locally and running it. I could see the looping behavior by adding a logging statement.

I ran the bard server locally with the fix and saw that the looping on my local client stopped.
Here are the [logs from bard dev](https://console.cloud.google.com/logs/query;query=%22request:failed%22;timeRange=2022-06-06T16:25:30.989Z%2F2022-06-06T16:40:30.989Z;cursorTimestamp=2022-06-06T16:39:42.043731747Z?referrer=search&project=terra-bard-dev) showing the event.

Here is a screenshot from mixpanel, showing events from my localhost are still making it to mixpanel with the new (temporary) wrapper:
![image](https://user-images.githubusercontent.com/50371603/172211162-c1511f25-de6a-429b-bc5a-1638251c9b66.png)
