### PR TITLE
SUP-686 Use Sam id when setting user email in MixPanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more info on how to leverage Mixpanel for your needs check out the documenta
 ## Developing
 Note that there is currently no separate development environment for mixpanel, so any changes will affect the real system. If you enable the mixpanel API with a token, events will get pushed to mixpanel. Use caution.
 
-1. Download a key for the app engine default service account terra-metrics-dev@appspot.gserviceaccount.com and note the location
+1. Create a new key for the app engine default service account terra-bard-dev@appspot.gserviceaccount.com. This will cause a JSON file to be downloaded to your machine. Note its location.
 2. Install the dependencies
 
     ```sh

--- a/src/server.js
+++ b/src/server.js
@@ -198,12 +198,15 @@ const main = async () => {
       { headers: { authorization: req.headers.authorization }, serviceName: 'profile' }
     )
 
-    // The user id we get back from Orch is only sometimes the same as the 
-    // Sam user id (req.user.userSubjectId). Make sure to use the Sam user 
-    // id when identifying users to MixPanel, since this is the identifier 
-    // used by all other Bard functions. See SUP-686 for more detail.
-    const { orchUserId, keyValuePairs } = await res.json()
-    const email = _.get('value', _.find({ key: 'anonymousGroup' }, keyValuePairs))
+    /*
+     * The user id we get back from Orch is only sometimes the same as the
+     * Sam user id (req.user.userSubjectId). Make sure to use the Sam user
+     * id when identifying users to MixPanel, since this is the identifier
+     * used by all other Bard functions. See SUP-686 for more detail.
+     */
+    const response = await res.json()
+    const email = _.get('value', _.find({ key: 'anonymousGroup' }, response.keyValuePairs))
+    console.log(email)
     const data = {
       '$token': token,
       '$distinct_id': userDistinctId(req.user),

--- a/src/server.js
+++ b/src/server.js
@@ -206,7 +206,6 @@ const main = async () => {
      */
     const response = await res.json()
     const email = _.get('value', _.find({ key: 'anonymousGroup' }, response.keyValuePairs))
-    console.log(email)
     const data = {
       '$token': token,
       '$distinct_id': userDistinctId(req.user),


### PR DESCRIPTION
I tested this with local Terra UI and dev Sam. My own dev Terra user displayed this problem: its anonymized email hadn't been synced properly to MixPanel. I reproduced the existing behavior with local Bard, then applied this change and logged into my local Terra again. That caused my traffic in MixPanel to be associated with a new user profile with the correct email set.

One potential problem is that this results in two MixPanel user profiles with the same email address, exactly one of which has traffic. I'm not sure how much MixPanel users care about this and am going to enquire.