### PR TITLE
DR-2988 - Fix for bard throwing 500 error sometimes

### DIFF
--- a/src/account-type-utils.js
+++ b/src/account-type-utils.js
@@ -60,7 +60,7 @@ const getAccountType = email => {
  *
  */
 const getEmailDomain = email => {
-  return _.includes(email, '@') || _.includes(email, '.')
+  return _.includes(email, '@') && _.includes(email, '.')
     ? _.last(email.split('@'))
     : 'Unknown'
 }

--- a/src/account-type-utils.js
+++ b/src/account-type-utils.js
@@ -60,7 +60,7 @@ const getAccountType = email => {
  *
  */
 const getEmailDomain = email => {
-  return email.includes('@') && email.includes('.')
+  return _.includes(email, '@') || _.includes(email, '.')
     ? _.last(email.split('@'))
     : 'Unknown'
 }


### PR DESCRIPTION
# PR Request Message
## Issue
Ticket: [DR-2988 Bard is throwing 500 error](https://broadworkbench.atlassian.net/browse/DR-2988)

## Cause
The issue occurs when using the native JavaScript `includes` function, which throws a 500 error when its target object is `undefined`. The reason for the object being `undefined` is not yet known, but it may be related to automation API users only in the TDR.

## Changes
To resolve this issue, I have replaced the native includes function with the `_.includes` function from the Lodash library. This change ensures the code can [handle the undefined use case](https://github.com/lodash/lodash/blob/2f79053d7bc7c9c9561a30dda202b3dcd2b72b90/test/includes.js#L71) without throwing a 500 error.
