### PR TITLE
[WM-1833] Add strict-transport-security header to responses

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,6 @@
 const _ = require('lodash/fp')
 const express = require('express')
 const cors = require('cors')
-const https = require('https')
 const bodyParser = require('body-parser')
 const { promiseHandler, Response, validateInput, redirectHandler, fetchOk, delay } = require('./utils')
 const { fetchMixpanel } = require('./mixpanel-utils')

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 const _ = require('lodash/fp')
 const express = require('express')
 const cors = require('cors')
+const https = require('https')
 const bodyParser = require('body-parser')
 const { promiseHandler, Response, validateInput, redirectHandler, fetchOk, delay } = require('./utils')
 const { fetchMixpanel } = require('./mixpanel-utils')
@@ -83,6 +84,10 @@ const main = async () => {
   app.use('/swagger', swaggerUi.serve,   swaggerUi.setup(swaggerDocument, options))
   // Redirect the root to the swagger ui
   app.get('/', redirectHandler('/swagger'))
+  app.use((req, res, next) => {
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload')
+    next()
+  })
 
   /**
    * @api {get} /status System status

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -91,6 +91,7 @@ describe('Test sending events', () => {
     const response = await request(app).post('/api/event')
       .send({ event: 'foo', properties: { appId: 'test', 'distinct_id': distinctId } })
     expect(response.statusCode).toBe(200)
+    expect(response.headers).toEqual(expect.objectContaining({ 'strict-transport-security': expect.anything() }))
     expect(log).toHaveBeenCalledTimes(1)
     expect(log.mock.calls[0][0].properties.terra_user_id).toBeUndefined()
     expect(numTimesVerifyAuthCalled[0]).toBe(0)
@@ -172,6 +173,7 @@ describe('Test identifying users', () => {
     const response = await request(app).post('/api/identify')
       .send({ anonId: distinctId })
     expect(response.statusCode).toBe(200)
+    expect(response.headers).toEqual(expect.objectContaining({ 'strict-transport-security': expect.anything() }))
     expect(log).toHaveBeenCalledTimes(1)
     expect(log.mock.calls[0][0]).toEqual({
       event: '$identify',
@@ -206,6 +208,7 @@ describe('Test syncing profiles', () => {
     mockSuccessfulMixpanelEngageTrackCall()
     const response = await request(app).post('/api/syncProfile')
     expect(response.statusCode).toBe(200)
+    expect(response.headers).toEqual(expect.objectContaining({ 'strict-transport-security': expect.anything() }))
     expect(log).toHaveBeenCalledTimes(1)
     expect(log.mock.calls[0][0]).toEqual({
       '$token': mixpanelToken,

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -60,6 +60,11 @@ describe('Test the root path', () => {
     const response = await request(app).get('/status')
     expect(response.statusCode).toBe(200)
   })
+
+  test('should return strict-transport-security headers', async () => {
+    const response = await request(app).get('/status')
+    expect(response.headers).toEqual(expect.objectContaining({ 'strict-transport-security': expect.anything() }))
+  })
 })
 
 describe('Test static docs', () => {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WM-1833

Added very simple middleware to attach the header to all responses, as well as a corresponding test