### PR TITLE
ID-1277 Use Map instead of Object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/server.js",
   "license": "MIT",
   "dependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -174,7 +174,7 @@ const main = async () => {
    *
    * @apiParam {String} eventName Name of the event
    * @apiParam {String} appId Name of the application
-   * @apiParam {Object} properties Properties associated with this event. Additional application defined fields can also be used.
+   * @apiParam {Map} properties Properties associated with this event. Additional application defined fields can also be used.
    * @apiParamExample {json} Event:
    * {
    *  "properties": {


### PR DESCRIPTION
Using `Map` instead of `Object` makes it so that the generated java client requires a type that can be serialized to JSON. Using `Object` allows the client to take any java object, which led me to try giving it a scala `Map`. This failed, as the internal Jackson JSON conversion doesn't know how to convert a scala `Map`. It knows how to convert a Java `Map`, though!