### PR TITLE
ID-1277 Add additional error handling/logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bard",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "src/server.js",
   "license": "MIT",
   "dependencies": {

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -49,7 +49,9 @@ jest.mock('./utils', () => {
 })
 
 jest.mock('jwt-decode', () => {
+  const originalModule = jest.requireActual('jwt-decode')
   return {
+    ...originalModule,
     jwtDecode: jest.fn()
   }
 })


### PR DESCRIPTION
After merging the last pr I noticed InvalidTokenError being thrown in the logs, this mean a malformed token is being passed in the authorization header to bard. Presumably sam's proxy would not allow any of these requests with malformed tokens to get to sam so I am catching these errors and returning 401 instead of the jwt-decode library throwing the error. 

I also noticed an error where a token would get parsed but there would be no 'email' field in the jwt. These requests will not be cached.