### PR TITLE
ID-1277 Change invalid token logging to include appid

### DIFF
--- a/src/sam-utils.js
+++ b/src/sam-utils.js
@@ -35,7 +35,7 @@ const verifyAuth = async req => {
   } catch (e) {
     // If the token is invalid we assume the request would have been rejected by sam's proxy anyways
     if (e instanceof InvalidTokenError) {
-      console.warn(`Invalid token from <${req.properties.appId}> "${e.message}"`)
+      console.warn(`Invalid token from <appId|"${req.body.properties.appId}"> <event|"${req.body.event}"> <error|"${e.message}">`)
       throw new Response(401, 'Invalid auth token')
     } else {
       throw e

--- a/src/sam-utils.js
+++ b/src/sam-utils.js
@@ -35,7 +35,7 @@ const verifyAuth = async req => {
   } catch (e) {
     // If the token is invalid we assume the request would have been rejected by sam's proxy anyways
     if (e instanceof InvalidTokenError) {
-      console.warn(`Invalid token from <${req.headers.host}> "${e.message}"`)
+      console.warn(`Invalid token from <${req.properties.appId}> "${e.message}"`)
       throw new Response(401, 'Invalid auth token')
     } else {
       throw e


### PR DESCRIPTION
The last pr to log the host header didnt work as expected. Thats actually just the host that the request is being sent to not where it originated as I had hoped. Logging appid should do the trick since it is a required field.