### PR TITLE
ID-1277 Replace cache key email with token

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "joi": "^17.6.0",
-    "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.7",

--- a/src/sam-utils.js
+++ b/src/sam-utils.js
@@ -1,48 +1,35 @@
 const { samRoot } = require('./config')
 const { fetchOk, Response } = require('./utils')
-const { jwtDecode, InvalidTokenError }   = require('jwt-decode')
 const NodeCache = require('node-cache')
 
 const samUserCache = new NodeCache({ stdTTL: 300, checkperiod: 300, maxKeys: 10000 })
 
-async function getSamUser(req, userEmail) {
+async function getSamUser(req) {
   const res = await fetchOk(
     `${samRoot}/register/user/v2/self/info`,
     { headers: { authorization: req.headers.authorization }, serviceName: 'auth' }
   )
   const samUser = await res.json()
-  samUserCache.set(userEmail, samUser)
-  req.user = samUser
+  samUserCache.set(req.headers.authorization, samUser)
+  return samUser
+}
+
+// Verify the user's auth token with Sam
+const verifyAuth = async req => {
+  // If no email is in the jwt skip checking the cache.
+  const maybeCachedUser = samUserCache.get(req.headers.authorization)
+
+  if (maybeCachedUser === undefined) {
+    req.user = await getSamUser(req)
+  } else {
+    req.user = maybeCachedUser
+  }
   if (!req.user.enabled) {
     throw new Response(403, 'Forbidden')
   }
 }
 
-// Verify the user's auth token with Sam
-const verifyAuth = async req => {
-  try {
-    const decodedToken = jwtDecode(req.headers.authorization.replace('Bearer ', ''))
-
-    const userEmail = decodedToken.email
-    // If no email is in the jwt skip checking the cache.
-    const maybeCachedUser = userEmail === undefined ? undefined : samUserCache.get(userEmail)
-
-    if (maybeCachedUser === undefined) {
-      await getSamUser(req, userEmail)
-    } else {
-      req.user = maybeCachedUser
-    }
-  } catch (e) {
-    // If the token is invalid we assume the request would have been rejected by sam's proxy anyways
-    if (e instanceof InvalidTokenError) {
-      console.warn(`Invalid token from <appId|"${req.body.properties.appId}"> <event|"${req.body.event}"> <error|"${e.message}">`)
-      throw new Response(401, 'Invalid auth token')
-    } else {
-      throw e
-    }
-  }
-}
-
 module.exports = {
-  verifyAuth
+  verifyAuth,
+  samUserCache
 }

--- a/src/sam-utils.js
+++ b/src/sam-utils.js
@@ -16,7 +16,6 @@ async function getSamUser(req) {
 
 // Verify the user's auth token with Sam
 const verifyAuth = async req => {
-  // If no email is in the jwt skip checking the cache.
   const maybeCachedUser = samUserCache.get(req.headers.authorization)
 
   if (maybeCachedUser === undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,11 +3937,6 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
-jwt-decode@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
-  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
-
 keyv@^4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.3.tgz#00873d2b046df737963157bd04f294ca818c9c25"


### PR DESCRIPTION
It turns out that google SA tokens are not JWT's so we are just storing sam user in the cache keyed on the token itself. It actually simplifies things a lot. 