### PR TITLE
ID-1276 Increase autoscaling min instances for app engine.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,3 +3,6 @@ handlers:
 - url: /.*
   secure: always
   script: auto
+automatic_scaling:
+  min_instances: 3
+  max_pending_latency: 500ms


### PR DESCRIPTION
With the inclusion of cromwell task metrics being sent to bard the number of requests bard handles has increased by an order of magnitude. In order to handle all of these requests we are increasing the minimum instance count bard has to 3 and adding a max latency autoscaling condition. 


Following this reference here https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=node.js#top