### PR TITLE
[WOR-1754] bump spring web version in javax and jakarta client

### DIFF
--- a/client-resttemplate-javax/templates/libraries/resttemplate/build.gradle.mustache
+++ b/client-resttemplate-javax/templates/libraries/resttemplate/build.gradle.mustache
@@ -57,7 +57,7 @@ ext {
     jakarta_annotation_version = "2.1.1"
     {{/useJakartaEe}}
     {{^useJakartaEe}}
-    spring_web_version = "5.3.33"
+    spring_web_version = "6.0.19"
     jakarta_annotation_version = "1.3.5"
     {{/useJakartaEe}}
     jodatime_version = "2.9.9"

--- a/client-resttemplate/templates/libraries/resttemplate/build.gradle.mustache
+++ b/client-resttemplate/templates/libraries/resttemplate/build.gradle.mustache
@@ -57,7 +57,7 @@ ext {
     jakarta_annotation_version = "2.1.1"
     {{/useJakartaEe}}
     {{^useJakartaEe}}
-    spring_web_version = "5.3.33"
+    spring_web_version = "6.0.19"
     jakarta_annotation_version = "1.3.5"
     {{/useJakartaEe}}
     jodatime_version = "2.9.9"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/WOR-1754

updating spring web version to address security ticket. I'll also publish a new version of both the javax and jakarta client. 

NOTE: There may be compatibility issues with the javax client between spring boot 2.x.x and spring web 6.x.x, so use caution if you are pulling in the new javax client version. The jakarta should be fully compatible since it requires spring boot 3.x.x

