### PR TITLE
[WX-1718] Update protobufjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ Note that there is currently no separate development environment for mixpanel, s
     yarn generate-docs
     ```
 
+### Updating dependencies
+
+- If the library is one of the direct dependencies, update the version in `package.json` and generate an updated `yarn.lock` file as detailed below.
+- If the library is a transitive dependency, delete the entries for the library in `yarn.lock`.
+- Make sure running `yarn --version` outputs the same version as the one [here](https://github.com/DataBiosphere/bard/blob/8298a1d5ff7eb8d754394c166668becddb395de8/.yarnrc#L5).
+- Run `yarn install` to generate the new content in `yarn.lock`. Verify the library versions satisfy the security update.
+- Run `yarn dedupe` to remove duplicated content from the `yarn.lock` file.
+- Create a PR with the modified files.
+
+Note: This is copied from [Terra UI's Wiki](https://github.com/DataBiosphere/terra-ui/wiki/Security-and-Maintenance#dependabot-security-updates). If above steps doesn't work please refer the Wiki and update the above steps as needed.
 
 
 ## Deploying

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "resolutions": {
     "glob": "^9.0.0",
     "optionator": "^0.9.3",
-    "semver": "^7.5.2"
+    "semver": "^7.5.2",
+    "protobufjs": "^7.2.5"
   },
   "scripts": {
     "generate-docs": "apidoc -i src -o docs && yarn generate-swagger",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4598,10 +4598,28 @@ protobufjs-cli@1.1.1:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@7.2.4, protobufjs@^7.0.0, protobufjs@^7.2.4:
+protobufjs@7.2.4:
   version "7.2.4"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
   integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
+protobufjs@^7.0.0, protobufjs@^7.2.4:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.2.tgz#60f3b7624968868f6f739430cfbc8c9370e26df4"
+  integrity sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4598,25 +4598,7 @@ protobufjs-cli@1.1.1:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@7.2.4:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
-  integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
-
-protobufjs@^7.0.0, protobufjs@^7.2.4:
+protobufjs@7.2.4, protobufjs@^7.0.0, protobufjs@^7.2.4, protobufjs@^7.2.5:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.2.tgz#60f3b7624968868f6f739430cfbc8c9370e26df4"
   integrity sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/WX-1718

Before changes:
``` 
%  yarn why protobufjs   
yarn why v1.22.0
warning ../../../package.json: No license field
[1/4] 🤔  Why do we have the module "protobufjs"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "protobufjs@7.2.4"
info Reasons this module exists
   - "@google-cloud#logging#google-gax" depends on it
   - Hoisted from "@google-cloud#logging#google-gax#protobufjs"
   - Hoisted from "@google-cloud#logging#google-gax#proto3-json-serializer#protobufjs"
   - Hoisted from "@google-cloud#logging#google-gax#@grpc#proto-loader#protobufjs"
info Disk size without dependencies: "2.85MB"
info Disk size with unique dependencies: "7.23MB"
info Disk size with transitive dependencies: "7.23MB"
info Number of shared dependencies: 12
✨  Done in 0.17s.
```

After changes:
```
% yarn why protobufjs
yarn why v1.22.0
warning ../../../package.json: No license field
[1/4] 🤔  Why do we have the module "protobufjs"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "protobufjs@7.3.2"
info Reasons this module exists
   - "@google-cloud#logging#google-gax" depends on it
   - Hoisted from "@google-cloud#logging#google-gax#protobufjs"
   - Hoisted from "@google-cloud#logging#google-gax#proto3-json-serializer#protobufjs"
   - Hoisted from "@google-cloud#logging#google-gax#@grpc#proto-loader#protobufjs"
info Disk size without dependencies: "3.11MB"
info Disk size with unique dependencies: "7.55MB"
info Disk size with transitive dependencies: "7.55MB"
info Number of shared dependencies: 12
✨  Done in 0.17s.

```