### PR TITLE
CORE-79: update spring-web and jackson versions for client

### DIFF
--- a/client-resttemplate/templates/libraries/resttemplate/build.gradle.mustache
+++ b/client-resttemplate/templates/libraries/resttemplate/build.gradle.mustache
@@ -47,13 +47,13 @@ ext {
     {{#swagger2AnnotationLibrary}}
     swagger_annotations_version = "2.2.9"
     {{/swagger2AnnotationLibrary}}
-    jackson_version = "2.17.1"
-    jackson_databind_version = "2.17.1"
+    jackson_version = "2.17.2"
+    jackson_databind_version = "2.17.2"
     {{#openApiNullable}}
     jackson_databind_nullable_version = "0.2.6"
     {{/openApiNullable}}
     {{#useJakartaEe}}
-    spring_web_version = "6.1.6"
+    spring_web_version = "6.1.13"
     jakarta_annotation_version = "2.1.1"
     {{/useJakartaEe}}
     {{^useJakartaEe}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bard",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "src/server.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-79 is a security finding on Rawls about spring-web 6.1.6.

Rawls pulls in spring-web 6.1.6 via the Bard client. This PR updates the version of spring-web in the Bard client so any users of the client will have an updated version.

I tweaked the patch version of Jackson while I was in there.

I modeled this PR after #89.