### PR TITLE
[AN-208] Removing header in app.yaml that cannot be parsed

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,8 +3,6 @@ handlers:
 - url: /.*
   secure: always
   script: auto
-  http_headers:
-    Content-Security-Policy: "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none'; frame-ancestors 'none';"
 automatic_scaling:
   min_instances: 3
   max_pending_latency: 500ms

--- a/src/app.js
+++ b/src/app.js
@@ -75,23 +75,22 @@ const main = async () => {
 
   app.use(bodyParser.json())
   app.use(cors())
+  app.use((req, res, next) => {
+    res.setHeader('Content-Security-Policy', 'default-src \'self\'; script-src \'self\' \'unsafe-inline\'; img-src \'self\' data:; style-src \'self\' \'unsafe-inline\'; connect-src \'self\'; form-action \'none\'; frame-ancestors \'none\';')
+    next()
+  })
   app.use('/docs', express.static('docs'))
   // Host the swagger ui
   const options = {
     explorer: true
   }
   app.use('/swagger', swaggerUi.serve,   swaggerUi.setup(swaggerDocument, options))
-  app.use((req, res, next) => {
-    res.setHeader('Content-Security-Policy', 'default-src \'self\'; script-src \'self\' \'unsafe-inline\'; img-src \'self\' data:; style-src \'self\' \'unsafe-inline\'; connect-src \'self\'; form-action \'none\'; frame-ancestors \'none\';')
-    next()
-  })
   // Redirect the root to the swagger ui
   app.get('/', redirectHandler('/swagger'))
   app.use((req, res, next) => {
     res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload')
     next()
   })
-
   /**
    * @api {get} /status System status
    * @apiName status

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -77,6 +77,11 @@ describe('Test static docs', () => {
     expect(response.headers).toEqual(expect.objectContaining({ 'content-security-policy': expect.anything() }))
   })
 
+  test('should return content-security-policy headers', async () => {
+    const response = await request(app).get('/swagger/')
+    expect(response.headers).toEqual(expect.objectContaining({ 'content-security-policy': expect.anything() }))
+  })
+
   test('calling docs shows apidocs page', async () => {
     const response = await request(app).get('/docs/')
     expect(response.statusCode).toBe(200)


### PR DESCRIPTION
JIRA ticket: https://broadworkbench.atlassian.net/browse/AN-208

Of course there was an error with the CI job to deploy my previous PR to dev... So I ended up manually deploying these changes to dev after fixing the typo, and confirmed that the CSP header is present on the swagger page:

<img width="1498" alt="Screenshot 2024-11-15 at 12 21 08 PM" src="https://github.com/user-attachments/assets/b34a7b86-89f8-4bf4-a354-147ab0ca8406">
