### PR TITLE
[CTM-464] Re-update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "path-to-regexp": "^0.1.12",
     "tmp": "^0.2.4",
     "brace-expansion": "^2.0.2",
-    "cookie": "^0.7.0"
+    "cookie": "^0.7.0",
+    "lodash": "^4.18.1"
   },
   "scripts": {
     "generate-docs": "apidoc -i src -o docs && yarn generate-swagger",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4357,12 +4357,7 @@ lodash.range@^3.2.0:
   resolved "https://registry.npmjs.org/lodash.range/-/lodash.range-3.2.0.tgz"
   integrity sha512-Fgkb7SinmuzqgIhNhAElo0BL/R1rHCnhwSZf78omqSwvWqD0kD2ssOAutQonDKH/ldS8BxA72ORYI09qAY9CYg==
 
-lodash@^4.17.15, lodash@^4.17.21, lodash@~4.17.4:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
-
-lodash@^4.18.1:
+lodash@^4.17.15, lodash@^4.17.21, lodash@^4.18.1, lodash@~4.17.4:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -4949,7 +4944,7 @@ protobufjs-cli@1.1.1:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
-protobufjs@7.2.4, protobufjs@^7.0.0, protobufjs@^7.2.4, protobufjs@^7.2.5:
+protobufjs@7.2.4, protobufjs@7.3.2, protobufjs@^7.0.0, protobufjs@^7.2.4:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.2.tgz#60f3b7624968868f6f739430cfbc8c9370e26df4"
   integrity sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-464

https://github.com/DataBiosphere/bard/pull/110 updated lodash but another dependency was still pulling in the vulnerable version.  Adds "lodash": "^4.18.1" to the resolutions field in package.json. Yarn's resolutions override transitive dependency version constraints, forcing all consumers to use 4.18.1. 